### PR TITLE
Add global environ value setting, allow unsafe url

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ You don't need any other tool except a browser to deploy this.
 2. Create an application in **Heroku Dashboard**, you will be redirected to **Settings** of your newly created application.
 3. Find **Config Variables** in **Settings** segment, click **Reveal Config Vars**, then press **Edit**
 4. Add a new variable, the **key** is ````BUILDPACK_URL````, and the **value** is ````https://github.com/heroku/heroku-buildpack-multi````, click **Save**.
-5. Find **Connect to Github** in **Deploy** segment, gives Heroku your Github access, then type **the repo name that you've forked**, click **Connect**.
-6. Find **Manual deploy**, click **Deploy Branch**.
-7. Done!
-8. Please note a Thumbor running without security key is dangerous, you'd better to change it. It's located in thumbor.conf. uncomment and set ````SECURITY_KEY```` to your key if you can.
+5. Again, add a new variable, the **key** is ````THUMBOR_SECURITY_KEY````, and you should define your own key and put it into **value**. Please note a Thumbor running without security key is dangerous, you'd better to change it.
+6. Find **Connect to Github** in **Deploy** segment, gives Heroku your Github access, then type **the repo name that you've forked**, click **Connect**.
+7. Find **Manual deploy**, click **Deploy Branch**.
+8. Done!
 
 ##Support my work
 

--- a/thumbor.conf
+++ b/thumbor.conf
@@ -22,7 +22,9 @@ OPTIMIZERS = [
 ]
 
 # Running insecure Thumbor instance is dangerous, you'd better to set a key
-# SECURITY_KEY = '[YOUR KEY HERE]'
+SECURITY_KEY = os.environ.get('THUMBOR_SECURITY_KEY', '<insert your secret key>')
+
+ALLOW_UNSAFE_URL = True
 
 HTTP_LOADER_FORWARD_USER_AGENT = True
 

--- a/thumbor.conf
+++ b/thumbor.conf
@@ -1,3 +1,5 @@
+import os
+
 STORAGE = "thumbor.storages.mixed_storage"
 
 MIXED_STORAGE_FILE_STORAGE = "thumbor.storages.no_storage"


### PR DESCRIPTION
User can define their THUMBOR_SECURITY_KEY directly in the control panel, no longer need to change the `thumbor.conf` in the repository.

Also, `ALLOW_UNSAFE_URL` should be added.
